### PR TITLE
Allows importing this library using ES6 `import parseBarcode from 'gs1-barcode-parser'`

### DIFF
--- a/src/BarcodeParser.js
+++ b/src/BarcodeParser.js
@@ -14,7 +14,7 @@
  *
  * encapsulating the barcode parsing function in an anonymous, self-executing function
  */
-var parseBarcode = (function () {
+export default parseBarcode = (function () {
     'use strict';
     /**
      * This is the main routine provided by the parseBarcode library. It takes a string,

--- a/src/BarcodeParser.js
+++ b/src/BarcodeParser.js
@@ -14,7 +14,7 @@
  *
  * encapsulating the barcode parsing function in an anonymous, self-executing function
  */
-export default parseBarcode = (function () {
+export default const parseBarcode = (function () {
     'use strict';
     /**
      * This is the main routine provided by the parseBarcode library. It takes a string,

--- a/src/BarcodeParser.js
+++ b/src/BarcodeParser.js
@@ -14,7 +14,7 @@
  *
  * encapsulating the barcode parsing function in an anonymous, self-executing function
  */
-export default const parseBarcode = (function () {
+const parseBarcode = (function () {
     'use strict';
     /**
      * This is the main routine provided by the parseBarcode library. It takes a string,
@@ -1363,3 +1363,5 @@ export default const parseBarcode = (function () {
     }
     return parseBarcode;
 }());
+
+export default parseBarcode;


### PR DESCRIPTION
This PR adds a default export of the `parseBarcode` function so that we can import it using the ES6 style:

```javascript
import parseBarcode from 'gs1-barcode-parser'

parseBarcode(barcode)
```